### PR TITLE
Do not allow blank passwords

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    scim_engine (2.1.2)
+    scim_engine (2.1.3)
       nokogiri (>= 1.10.4)
       rails (>= 5.0)
 

--- a/app/controllers/scim_engine/application_controller.rb
+++ b/app/controllers/scim_engine/application_controller.rb
@@ -7,6 +7,8 @@ module ScimEngine
 
     def authenticated?
       authenticate_with_http_basic do |name, password|
+        return handle_unauthorized unless password.present?
+
         name == ScimEngine::Engine.username && password == ScimEngine::Engine.password
       end
     end
@@ -21,6 +23,10 @@ module ScimEngine
 
     def handle_record_invalid(error_message)
       handle_scim_error(ErrorResponse.new(status: 400, detail: "Operation failed since record has become invalid: #{error_message}"))
+    end
+
+    def handle_unauthorized
+      handle_scim_error(ErrorResponse.new(status: 401, detail: "Invalid credentails"))
     end
 
     def handle_scim_error(error_response)

--- a/lib/scim_engine/version.rb
+++ b/lib/scim_engine/version.rb
@@ -1,3 +1,3 @@
 module ScimEngine
-  VERSION = "2.1.2"
+  VERSION = "2.1.3"
 end

--- a/spec/controllers/scim_engine/application_controller_spec.rb
+++ b/spec/controllers/scim_engine/application_controller_spec.rb
@@ -38,7 +38,6 @@ describe ScimEngine::ApplicationController do
       expect(response).not_to be_ok
     end
 
-
     it 'renders failure with bad user name and password' do
       request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('C', 'D')
 
@@ -46,8 +45,12 @@ describe ScimEngine::ApplicationController do
       expect(response).not_to be_ok
     end
 
+    it 'renders failure with blank password' do
+      request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials('A', '')
 
-
+      get :index, params: { format: :scim }
+      expect(response).not_to be_ok
+    end
   end
 
 


### PR DESCRIPTION
As a security enhancement, do not allow services calling the scim engine to use blank passwords